### PR TITLE
Expose story content to renderer

### DIFF
--- a/wp-content/plugins/veda-content-editor/src/story-renderer.jsx
+++ b/wp-content/plugins/veda-content-editor/src/story-renderer.jsx
@@ -77,9 +77,9 @@ function StoryRenderer({ mdxContent, postId }) {
           console.log('[VEDA] Using vedaEditor.currentContent');
         }
         // Source 3: Fetch from REST API
-        else if (postId && window.vedaEditor?.restNonce) {
+        else if (postId && window.vedaStoryData?.restNonce) {
           console.log('[VEDA] Attempting REST API fetch...');
-          const response = await fetch(`/wp-json/wp/v2/posts/${postId}?_wpnonce=${window.vedaEditor.restNonce}`);
+          const response = await fetch(`/wp-json/wp/v2/posts/${postId}?_wpnonce=${window.vedaStoryData.restNonce}`);
           
           if (response.ok) {
             const postData = await response.json();
@@ -88,13 +88,13 @@ function StoryRenderer({ mdxContent, postId }) {
           }
         }
         // Source 4: Try AJAX endpoint
-        else if (postId && window.vedaEditor?.ajaxUrl) {
+        else if (postId && window.vedaStoryData?.ajaxUrl) {
           console.log('[VEDA] Attempting AJAX fetch...');
           const formData = new FormData();
           formData.append('action', 'get_veda_story_content');
           formData.append('post_id', postId);
-          
-          const response = await fetch(window.vedaEditor.ajaxUrl, {
+
+          const response = await fetch(window.vedaStoryData.ajaxUrl, {
             method: 'POST',
             body: formData
           });

--- a/wp-content/plugins/veda-content-editor/veda-content-editor.php
+++ b/wp-content/plugins/veda-content-editor/veda-content-editor.php
@@ -7,6 +7,21 @@
 
 require_once plugin_dir_path(__FILE__) . 'post-type.php';
 
+// Register story content meta so it is available via the REST API
+add_action('init', function() {
+    register_post_meta('veda_story', '_veda_story_content', [
+        'show_in_rest' => [
+            'name' => 'veda_story_content',
+            'schema' => [
+                'type' => 'string',
+            ],
+        ],
+        'single' => true,
+        'type' => 'string',
+        'auth_callback' => '__return_true',
+    ]);
+});
+
 add_action('admin_enqueue_scripts', function ($hook) {
     global $post;
     if ('post.php' !== $hook && 'post-new.php' !== $hook) return;
@@ -134,6 +149,8 @@ add_action('wp_enqueue_scripts', function() {
             wp_localize_script('veda-story-renderer', 'vedaStoryData', [
                 'content' => $mdx_content ?? '',
                 'postId' => $post->ID,
+                'ajaxUrl' => admin_url('admin-ajax.php'),
+                'restNonce' => wp_create_nonce('wp_rest'),
             ]);
         }
     }


### PR DESCRIPTION
## Summary
- Register `_veda_story_content` post meta for REST access
- Localize AJAX URL and REST nonce to front-end story renderer
- Fetch story content on the front-end using localized AJAX/REST data

## Testing
- `BUILD_TARGET=story-renderer npm run build -- --emptyOutDir=false` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a371db1ec83328324ddc72628c7a1