### PR TITLE
Ensure VEDA editor save requests send credentials

### DIFF
--- a/wp-content/plugins/veda-content-editor/src/admin-editor.jsx
+++ b/wp-content/plugins/veda-content-editor/src/admin-editor.jsx
@@ -54,6 +54,7 @@ function VEDAStoryEditor({ initialContent, postId, onSave }) {
         try {
             const response = await fetch(window.vedaEditor.ajaxUrl, {
                 method: 'POST',
+                credentials: 'same-origin',
                 headers: {
                     'Content-Type': 'application/x-www-form-urlencoded',
                 },
@@ -86,7 +87,8 @@ function VEDAStoryEditor({ initialContent, postId, onSave }) {
         
         try {
             const response = await fetch(window.vedaEditor.saveEndpoint, {
-                method: 'POST',
+                  method: 'POST',
+                  credentials: 'same-origin',
                 headers: {
                     'Content-Type': 'application/json',
                     'X-WP-Nonce': window.vedaEditor.restNonce

--- a/wp-content/plugins/veda-content-editor/src/story-editor.jsx
+++ b/wp-content/plugins/veda-content-editor/src/story-editor.jsx
@@ -61,6 +61,7 @@ function VEDAEditorHost({ initialContent, postId }) {
     try {
       const response = await fetch(window.vedaEditor?.saveEndpoint || window.vedaEditor?.ajaxUrl, {
         method: 'POST',
+        credentials: 'same-origin',
         headers: {
           'Content-Type': 'application/json',
           'X-WP-Nonce': window.vedaEditor?.restNonce || ''


### PR DESCRIPTION
## Summary
- include `credentials: 'same-origin'` on manual and auto-save fetch calls
- update compiled story-editor bundle with the new credentials option

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*
- `yarn build` *(fails: package doesn't seem present in lockfile; run "yarn install" to update the lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_689a4237b1f08332a871279956d5ecc6